### PR TITLE
Propagate exit status of child process to main process

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,13 @@ fn main() {
         return;
     }
 
-    let _ = mask::executor::execute_command(chosen_cmd.unwrap());
+    match mask::executor::execute_command(chosen_cmd.unwrap()) {
+        Ok(status) => match status.code() {
+            Some(code) => std::process::exit(code),
+            None       => return
+        },
+        Err(err) => eprintln!("ERROR: {}", err)
+    }
 }
 
 fn build_subcommands<'a, 'b>(


### PR DESCRIPTION
If the task is exited with non-zero status, `mask` itself exit with that status.
Because i used this in the CI pipeline.

## maskfile.md

```
## test

~~~sh
exit 1
~~~
```

### Current Behavior


```
$ mask test
$ echo $?
0
```

### Changed Behavior

```
$ mask test
$ echo $?
1
```

Thanks to make very useful application :+1:
