### PR TITLE
Always exit with error when custom maskfile is not found

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,6 @@ fn main() {
 
     let maskfile = find_maskfile();
     if maskfile.is_err() {
-        println!("{} no maskfile.md found", "WARNING:".yellow());
         // If the maskfile can't be found, at least parse for --version or --help
         cli_app.get_matches();
         return;
@@ -54,6 +53,20 @@ fn find_maskfile() -> Result<String, String> {
     };
 
     let maskfile = mask::loader::read_maskfile(maskfile_path);
+
+    if maskfile.is_err() {
+        if let Some(p) = maskfile_path.to_str() {
+            // Check if this is a custom maskfile
+            if p != "./maskfile.md" {
+                // Exit with an error it's not found
+                eprintln!("{} specified maskfile not found", "ERROR:".red());
+                std::process::exit(1);
+            } else {
+                // Just log a warning and let the process continue
+                println!("{} no maskfile.md found", "WARNING:".yellow());
+            }
+        }
+    }
 
     maskfile
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -25,12 +25,14 @@ fn specifying_a_maskfile_in_a_different_dir() {
         .success();
 }
 
-mod when_no_maskfile_found {
+// Using current_dir(".github") to make sure the default maskfile.md can't be found
+mod when_no_maskfile_found_in_current_directory {
     use super::*;
 
     #[test]
-    fn logs_warning_about_missing_file() {
-        common::run_mask(&PathBuf::from("./nonexistent.md"))
+    fn logs_warning_about_missing_maskfile_when_its_not_custom() {
+        common::run_mask(&PathBuf::from("./maskfile.md"))
+            .current_dir(".github")
             .assert()
             .stdout(contains(format!(
                 "{} no maskfile.md found",
@@ -41,7 +43,8 @@ mod when_no_maskfile_found {
 
     #[test]
     fn exits_without_error_for_help() {
-        common::run_mask(&PathBuf::from("./nonexistent.md"))
+        common::run_mask(&PathBuf::from("./maskfile.md"))
+            .current_dir(".github")
             .command("--help")
             .assert()
             .stdout(contains("USAGE:"))
@@ -50,7 +53,8 @@ mod when_no_maskfile_found {
 
     #[test]
     fn exits_without_error_for_version() {
-        common::run_mask(&PathBuf::from("./nonexistent.md"))
+        common::run_mask(&PathBuf::from("./maskfile.md"))
+            .current_dir(".github")
             .command("--version")
             .assert()
             .stdout(contains(format!("{} {}", crate_name!(), crate_version!())))
@@ -59,10 +63,51 @@ mod when_no_maskfile_found {
 
     #[test]
     fn exits_with_error_for_any_other_command() {
-        common::run_mask(&PathBuf::from("./nonexistent.md"))
-            .command("yasss")
+        common::run_mask(&PathBuf::from("./maskfile.md"))
+            .current_dir(".github")
+            .command("nothing")
             .assert()
-            .stderr(contains("error: Found argument 'yasss' which wasn't expected, or isn't valid in this context"))
+            .stderr(contains("error: Found argument 'nothing' which wasn't expected, or isn't valid in this context"))
+            .failure();
+    }
+}
+
+mod when_custom_specified_maskfile_not_found {
+    use super::*;
+
+    #[test]
+    fn exits_with_error_for_help() {
+        common::run_mask(&PathBuf::from("./nonexistent.md"))
+            .command("--help")
+            .assert()
+            .stderr(contains(format!(
+                "{} specified maskfile not found",
+                "ERROR:".red()
+            )))
+            .failure();
+    }
+
+    #[test]
+    fn exits_with_error_for_version() {
+        common::run_mask(&PathBuf::from("./nonexistent.md"))
+            .command("--version")
+            .assert()
+            .stderr(contains(format!(
+                "{} specified maskfile not found",
+                "ERROR:".red()
+            )))
+            .failure();
+    }
+
+    #[test]
+    fn exits_with_error_for_any_other_command() {
+        common::run_mask(&PathBuf::from("./nonexistent.md"))
+            .command("what")
+            .assert()
+            .stderr(contains(format!(
+                "{} specified maskfile not found",
+                "ERROR:".red()
+            )))
             .failure();
     }
 }


### PR DESCRIPTION
### Describe the solution
<!-- Add some details about what you did to fix the issue. -->
In #23, I allowed mask to not exit with an error when there's a missing maskfile. That is ideal behavior when you just want to run `mask --version` or `mask --help` in any directory, no matter if it has a maskfile.md or not. However, when you go to the extent of specifying `mask --maskfile /path/to/some/nonexistent_maskfile.md`, this should have caused mask to exit with an error message no matter what. 

This PR fixes that behavior and properly exits mask when `--maskfile` points to an actual missing file.


### How to test
<!-- Describe how to test this PR and check the boxes if you added tests -->

- [ ] Added unit tests
- [x] Added integration tests



### Types of changes
<!-- What types of changes does your code introduce? -->
Breaking change because it affects which status code mask exits with.

- [x] Bug fix               <!-- non-breaking change which fixes an issue -->
- [ ] New feature           <!-- non-breaking change which adds functionality -->
- [x] Breaking change       <!-- fix or feature that would cause existing functionality to not work as expected -->
