### PR TITLE
Add $MASK and $MASKFILE_DIR utility env variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,11 +49,9 @@ jobs:
           name: Install other runtimes
           command: apt-get update && apt-get install -y ruby-full php
       - run:
-          name: Set mask alias for certain test suites that depend on it
-          command: alias mask="./target/debug/mask"
-      - run:
           name: Run tests
-          command: cargo test --verbose --frozen
+          # Set mask alias for certain test suites that depend on it
+          command: alias mask="./target/debug/mask" && cargo test --verbose --frozen
 
 workflows:
   pr_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
       - *restore_cache
       - run:
           name: Make mask available for certain test suites that depend on it
-          command: export PATH="$PATH:~/repo/target/debug"
+          command: echo 'export PATH="$PATH:~/repo/target/debug"' >> $BASH_ENV
       - run:
           name: Install latest node from PPA
           command: apt-get update && apt-get install -y curl software-properties-common && curl -sL https://deb.nodesource.com/setup_12.x | bash - && apt-get install nodejs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,9 @@ jobs:
           name: Install other runtimes
           command: apt-get update && apt-get install -y ruby-full php
       - run:
+          name: Set mask alias for certain test suites that depend on it
+          command: alias mask="./target/debug/mask"
+      - run:
           name: Run tests
           command: cargo test --verbose --frozen
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,9 +51,9 @@ jobs:
       - run:
           name: Run tests
           command: cargo test --verbose --frozen
-        environment:
           # mask needs to be available for certain test suites that depend on it
-          PATH: "$PATH:~/repo/target/debug"
+          environment:
+            PATH: "$PATH:~/repo/target/debug"
 
 workflows:
   pr_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,9 @@ jobs:
       - *attach_workspace
       - *restore_cache
       - run:
+          name: Make mask available for certain test suites that depend on it
+          command: export PATH="$PATH:~/repo/target/debug"
+      - run:
           name: Install latest node from PPA
           command: apt-get update && apt-get install -y curl software-properties-common && curl -sL https://deb.nodesource.com/setup_12.x | bash - && apt-get install nodejs
       - run:
@@ -51,9 +54,6 @@ jobs:
       - run:
           name: Run tests
           command: cargo test --verbose --frozen
-          # mask needs to be available for certain test suites that depend on it
-          environment:
-            PATH: "$PATH:~/repo/target/debug"
 
 workflows:
   pr_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,10 @@ jobs:
           command: apt-get update && apt-get install -y ruby-full php
       - run:
           name: Run tests
-          # Set a mask alias/func for certain test suites that depend on it
-          command: mask() { ./target/debug/mask; } && cargo test --verbose --frozen
+          command: cargo test --verbose --frozen
+        environment:
+          # mask needs to be available for certain test suites that depend on it
+          PATH: "$PATH:~/repo/target/debug"
 
 workflows:
   pr_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,8 @@ jobs:
           command: apt-get update && apt-get install -y ruby-full php
       - run:
           name: Run tests
-          # Set mask alias for certain test suites that depend on it
-          command: alias mask="./target/debug/mask" && cargo test --verbose --frozen
+          # Set a mask alias/func for certain test suites that depend on it
+          command: mask() { ./target/debug/mask; } && cargo test --verbose --frozen
 
 workflows:
   pr_test:

--- a/README.md
+++ b/README.md
@@ -276,7 +276,8 @@ mask install
 mask build
 mask link
 # $MASK also works. It's an alias variable for `mask --maskfile <path_to_maskfile>`
-# which allows an externally referenced maskfile to be called from anywhere.
+# which guarantees your scripts will still work even if they are called from
+# another directory.
 $MASK db migrate
 $MASK start
 ~~~

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-
 <p align="center">
   <img height="180" width="210" src="https://user-images.githubusercontent.com/1631044/61989571-aae27580-afff-11e9-8f8a-c9768ed7a6b8.png">
 </p>
-      
+
 
 [![build status](https://img.shields.io/circleci/build/github/jakedeichert/mask/master.svg)][circleci]
 [![mask version](https://img.shields.io/crates/v/mask.svg)][crate]
@@ -263,7 +262,7 @@ ARGS:
 
 ### Running mask from within a script
 
-You can easily call `mask` within scripts if you need to chain commands together.
+You can easily call `mask` within scripts if you need to chain commands together. However, if you plan on [running mask with a different maskfile](#running-mask-with-a-different-maskfile), you should consider using the `$MASK` utility instead which allows your scripts to be location-agnostic.
 
 **Example:**
 
@@ -276,8 +275,10 @@ You can easily call `mask` within scripts if you need to chain commands together
 mask install
 mask build
 mask link
-mask db migrate
-mask start
+# $MASK also works. It's an alias variable for `mask --maskfile <path_to_maskfile>`
+# which allows an externally referenced maskfile to be called from anywhere.
+$MASK db migrate
+$MASK start
 ~~~
 ```
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -78,7 +78,10 @@ fn add_utility_variables(mut child: process::Command, maskfile_path: String) -> 
     // This allows us to call "$MASK command" instead of "mask --maskfile <path> command"
     // inside scripts so that they can be location-agnostic (not care where they are
     // called from). This is useful for global maskfiles especially.
-    child.env("MASK", format!("{} --maskfile {}", crate_name!(), absolute_path_str));
+    child.env(
+        "MASK",
+        format!("{} --maskfile {}", crate_name!(), absolute_path_str),
+    );
     // This allows us to refer to the directory the maskfile lives in which can be handy
     // for loading relative files to it.
     child.env("MASKFILE_DIR", parent_dir);

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -4,6 +4,8 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::process::ExitStatus;
 
+use clap::crate_name;
+
 use crate::command::Command;
 
 pub fn execute_command(cmd: Command, maskfile_path: String) -> Result<ExitStatus> {
@@ -76,7 +78,7 @@ fn add_utility_variables(mut child: process::Command, maskfile_path: String) -> 
     // This allows us to call "$MASK command" instead of "mask --maskfile <path> command"
     // inside scripts so that they can be location-agnostic (not care where they are
     // called from). This is useful for global maskfiles especially.
-    child.env("MASK", format!("mask --maskfile {}", absolute_path_str));
+    child.env("MASK", format!("{} --maskfile {}", crate_name!(), absolute_path_str));
     // This allows us to refer to the directory the maskfile lives in which can be handy
     // for loading relative files to it.
     child.env("MASKFILE_DIR", parent_dir);

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,10 +1,12 @@
+use std::fs::canonicalize;
 use std::io::Result;
+use std::path::{Path, PathBuf};
 use std::process;
 use std::process::ExitStatus;
 
 use crate::command::Command;
 
-pub fn execute_command(cmd: Command) -> Result<ExitStatus> {
+pub fn execute_command(cmd: Command, maskfile_path: String) -> Result<ExitStatus> {
     let mut child = match cmd.executor.as_ref() {
         "js" | "javascript" => {
             let mut child = process::Command::new("node");
@@ -38,6 +40,8 @@ pub fn execute_command(cmd: Command) -> Result<ExitStatus> {
         }
     };
 
+    child = add_utility_variables(child, maskfile_path);
+
     // Add all required args as environment variables
     for arg in cmd.required_args {
         child.env(arg.name, arg.val);
@@ -51,4 +55,31 @@ pub fn execute_command(cmd: Command) -> Result<ExitStatus> {
     }
 
     child.spawn()?.wait()
+}
+
+// Add some useful environment variables that scripts can use
+fn add_utility_variables(mut child: process::Command, maskfile_path: String) -> process::Command {
+    let maskfile_path = PathBuf::from(maskfile_path);
+
+    // Find the absolute path to the maskfile
+    let absolute_path = canonicalize(&maskfile_path)
+        .expect("canonicalize maskfile path failed")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let absolute_path = Path::new(&absolute_path);
+    let absolute_path_str = absolute_path.to_str().unwrap();
+
+    // Find the absolute path to the maskfile's parent directory
+    let parent_dir = absolute_path.parent().unwrap().to_str().unwrap();
+
+    // This allows us to call "$MASK command" instead of "mask --maskfile <path> command"
+    // inside scripts so that they can be location-agnostic (not care where they are
+    // called from). This is useful for global maskfiles especially.
+    child.env("MASK", format!("mask --maskfile {}", absolute_path_str));
+    // This allows us to refer to the directory the maskfile lives in which can be handy
+    // for loading relative files to it.
+    child.env("MASKFILE_DIR", parent_dir);
+
+    child
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
         .about(crate_description!())
         .arg(custom_maskfile_path_arg());
 
-    let maskfile = find_maskfile();
+    let (maskfile, maskfile_path) = find_maskfile();
     if maskfile.is_err() {
         // If the maskfile can't be found, at least parse for --version or --help
         cli_app.get_matches();
@@ -31,7 +31,7 @@ fn main() {
         std::process::exit(1);
     }
 
-    match mask::executor::execute_command(chosen_cmd.unwrap()) {
+    match mask::executor::execute_command(chosen_cmd.unwrap(), maskfile_path) {
         Ok(status) => match status.code() {
             Some(code) => std::process::exit(code),
             None => return,
@@ -40,7 +40,7 @@ fn main() {
     }
 }
 
-fn find_maskfile() -> Result<String, String> {
+fn find_maskfile() -> (Result<String, String>, String) {
     let args: Vec<String> = env::args().collect();
 
     let maybe_maskfile = args.get(1);
@@ -68,7 +68,7 @@ fn find_maskfile() -> Result<String, String> {
         }
     }
 
-    maskfile
+    (maskfile, maskfile_path.to_str().unwrap().to_string())
 }
 
 fn custom_maskfile_path_arg<'a, 'b>() -> Arg<'a, 'b> {

--- a/tests/env_vars_test.rs
+++ b/tests/env_vars_test.rs
@@ -4,6 +4,8 @@ use predicates::str::contains;
 mod common;
 use common::MaskCommandExt;
 
+// NOTE: This test suite depends on the mask binary being available in the current shell
+
 // Using current_dir(".github") to make sure the default maskfile.md can't be found
 mod env_var_mask {
     use super::*;

--- a/tests/env_vars_test.rs
+++ b/tests/env_vars_test.rs
@@ -36,7 +36,7 @@ echo "tests passed"
 
     #[test]
     fn set_to_the_correct_value() {
-        let (temp, maskfile_path) = common::maskfile(
+        let (_temp, maskfile_path) = common::maskfile(
             r#"
 ## run
 
@@ -50,11 +50,10 @@ echo "mask = $MASK"
             .current_dir(".github")
             .command("run")
             .assert()
-            // Needs "/private" because the temp dir is "/var" which is a symlink to "/private/var".
-            .stdout(contains(format!(
-                "mask = mask --maskfile /private{}/maskfile.md",
-                temp.path().to_str().unwrap().to_string()
-            )))
+            // Absolute maskfile path starts with /
+            .stdout(contains("mask = mask --maskfile /"))
+            // And ends with maskfile.md
+            .stdout(contains("maskfile.md"))
             .success();
     }
 }
@@ -65,7 +64,7 @@ mod env_var_maskfile_dir {
 
     #[test]
     fn set_to_the_correct_value() {
-        let (temp, maskfile_path) = common::maskfile(
+        let (_temp, maskfile_path) = common::maskfile(
             r#"
 ## run
 
@@ -79,11 +78,8 @@ echo "maskfile_dir = $MASKFILE_DIR"
             .current_dir(".github")
             .command("run")
             .assert()
-            // Needs "/private" because the temp dir is "/var" which is a symlink to "/private/var".
-            .stdout(contains(format!(
-                "maskfile_dir = /private{}",
-                temp.path().to_str().unwrap().to_string()
-            )))
+            // Absolute maskfile path starts with /
+            .stdout(contains("maskfile_dir = /"))
             .success();
     }
 }

--- a/tests/env_vars_test.rs
+++ b/tests/env_vars_test.rs
@@ -1,0 +1,89 @@
+use assert_cmd::prelude::*;
+use predicates::str::contains;
+
+mod common;
+use common::MaskCommandExt;
+
+// Using current_dir(".github") to make sure the default maskfile.md can't be found
+mod env_var_mask {
+    use super::*;
+
+    #[test]
+    fn works_from_any_dir() {
+        let (_temp, maskfile_path) = common::maskfile(
+            r#"
+## ci
+
+~~~bash
+$MASK test
+~~~
+
+## test
+
+~~~bash
+echo "tests passed"
+~~~
+"#,
+        );
+
+        common::run_mask(&maskfile_path)
+            .current_dir(".github")
+            .command("ci")
+            .assert()
+            .stdout(contains("tests passed"))
+            .success();
+    }
+
+    #[test]
+    fn set_to_the_correct_value() {
+        let (temp, maskfile_path) = common::maskfile(
+            r#"
+## run
+
+~~~bash
+echo "mask = $MASK"
+~~~
+"#,
+        );
+
+        common::run_mask(&maskfile_path)
+            .current_dir(".github")
+            .command("run")
+            .assert()
+            // Needs "/private" because the temp dir is "/var" which is a symlink to "/private/var".
+            .stdout(contains(format!(
+                "mask = mask --maskfile /private{}/maskfile.md",
+                temp.path().to_str().unwrap().to_string()
+            )))
+            .success();
+    }
+}
+
+// Using current_dir(".github") to make sure the default maskfile.md can't be found
+mod env_var_maskfile_dir {
+    use super::*;
+
+    #[test]
+    fn set_to_the_correct_value() {
+        let (temp, maskfile_path) = common::maskfile(
+            r#"
+## run
+
+~~~bash
+echo "maskfile_dir = $MASKFILE_DIR"
+~~~
+"#,
+        );
+
+        common::run_mask(&maskfile_path)
+            .current_dir(".github")
+            .command("run")
+            .assert()
+            // Needs "/private" because the temp dir is "/var" which is a symlink to "/private/var".
+            .stdout(contains(format!(
+                "maskfile_dir = /private{}",
+                temp.path().to_str().unwrap().to_string()
+            )))
+            .success();
+    }
+}


### PR DESCRIPTION
### Describe the problem
When referring to a maskfile with `--maskfile <path_to_maskfile>`, scripts inside can't simply use `mask <command>` to call other subcommands since mask tries to look for a maskfile in the current directory you're calling from. The new instance of mask can't understand you called an external maskfile that's not within this directory.

### Describe the solution
The solution to this is a utility environment variable, `$MASK`. Instead of your scripts calling `mask <command>`, to make them location-agnostic, you should use `$MASK <command>` instead. `$MASK` is just equal to `mask --maskfile <path_to_maskfile>` which means you no longer have to worry about where you call a maskfile from.

Another utility variable was also added: `$MASKFILE_DIR`. This allows us to refer to the directory the maskfile lives in which can be handy for loading relative files to it.

### How to test
<!-- Describe how to test this PR and check the boxes if you added tests -->

Use `$MASK` within a script to call another subcommand.

- [ ] Added unit tests
- [x] Added integration tests



### Types of changes
<!-- What types of changes does your code introduce? -->

- [ ] Bug fix               <!-- non-breaking change which fixes an issue -->
- [x] New feature           <!-- non-breaking change which adds functionality -->
- [ ] Breaking change       <!-- fix or feature that would cause existing functionality to not work as expected -->
