### PR TITLE
Error when command has no script and missing subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use mask::executor::execute_command;
 
 fn main() {
     let cli_app = App::new(crate_name!())
+        .setting(AppSettings::VersionlessSubcommands)
         .setting(AppSettings::SubcommandRequired)
         .version(crate_version!())
         .author(crate_authors!())

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -30,15 +30,15 @@ mod when_no_maskfile_found_in_current_directory {
     use super::*;
 
     #[test]
-    fn logs_warning_about_missing_maskfile_when_its_not_custom() {
+    fn logs_warning_about_missing_maskfile() {
         common::run_mask(&PathBuf::from("./maskfile.md"))
             .current_dir(".github")
+            .command("-V")
             .assert()
             .stdout(contains(format!(
                 "{} no maskfile.md found",
                 "WARNING:".yellow()
-            )))
-            .success();
+            )));
     }
 
     #[test]

--- a/tests/subcommands_test.rs
+++ b/tests/subcommands_test.rs
@@ -41,7 +41,7 @@ echo "Stopping service $service_name"
 }
 
 #[test]
-fn exits_with_error_when_missing_subcommnad() {
+fn exits_with_error_when_missing_subcommand() {
     let (_temp, maskfile_path) = common::maskfile(
         r#"
 ## foo
@@ -50,6 +50,8 @@ fn exits_with_error_when_missing_subcommnad() {
 
     common::run_mask(&maskfile_path)
         .assert()
-        .stderr(contains(format!("{} missing subcommand", "ERROR:".red())))
+        .stderr(contains(
+            "error: 'mask' requires a subcommand, but one was not provided",
+        ))
         .failure();
 }

--- a/tests/subcommands_test.rs
+++ b/tests/subcommands_test.rs
@@ -1,6 +1,5 @@
 use assert_cmd::prelude::*;
-use colored::*;
-use predicates::str::contains;
+use predicates::str::{contains, is_empty};
 
 mod common;
 
@@ -54,4 +53,48 @@ fn exits_with_error_when_missing_subcommand() {
             "error: 'mask' requires a subcommand, but one was not provided",
         ))
         .failure();
+}
+
+mod when_command_has_no_source {
+    use super::*;
+
+    #[test]
+    fn exits_gracefully_when_it_has_no_subcommands() {
+        let (_temp, maskfile_path) = common::maskfile(
+            r#"
+## system
+"#,
+        );
+
+        // NOTE: Right now we exit without an error. Perhaps there should at least
+        // be a warning logged to the console?
+        common::run_mask(&maskfile_path)
+            .command("system")
+            .assert()
+            .stdout(is_empty())
+            .success();
+    }
+
+    #[test]
+    fn exits_with_error_when_it_has_subcommands() {
+        let (_temp, maskfile_path) = common::maskfile(
+            r#"
+## system
+
+### start
+
+~~~sh
+echo "system, online"
+~~~
+"#,
+        );
+
+        common::run_mask(&maskfile_path)
+            .command("system")
+            .assert()
+            .stderr(contains(
+                "error: 'mask system' requires a subcommand, but one was not provided",
+            ))
+            .failure();
+    }
 }


### PR DESCRIPTION
### Describe the problem
When a parent command has no script source but it has subcommands, mask gracefully exited with no warning or error (nothing happened). If a parent command doesn't have a source, it should be required to have a subcommand or else an error should show.

### Describe the solution
I used clap's `SubcommandRequired` setting for the root command and for all subcommands that have no source but have children commands. Clap now shows a proper "missing command" error and a tip to try `--help`.

Also found out about this setting `VersionlessSubcommands` which I've also enabled. Subcommands don't need a version flag. The root command now is the only command with a version flag. 
`mask --version`



### How to test
<!-- Describe how to test this PR and check the boxes if you added tests -->

- [ ] Added unit tests
- [x] Added integration tests



### Types of changes
<!-- What types of changes does your code introduce? -->


- [x] Bug fix               <!-- non-breaking change which fixes an issue -->
- [ ] New feature           <!-- non-breaking change which adds functionality -->
- [x] Breaking change       <!-- fix or feature that would cause existing functionality to not work as expected -->
