### PR TITLE
No need to show mask's author and description in help output

### DIFF
--- a/maskfile.md
+++ b/maskfile.md
@@ -10,7 +10,7 @@
 
 > Build and run mask in development mode
 
-**NOTE:** This uses `cargo run` to build and run `mask` in development mode. You must have a `maskfile` in the current directory (this file) and must supply a valid command for that `maskfile` (`maskfile_command`) in order to test the changes you've made to `mask`. Since you can only test against this `maskfile` (for now), you can add subcommands to the bottom and run against those instead of running one of the existing commands.
+**NOTE:** This uses `cargo run` to build and run `mask` in development mode. You must have a `maskfile` in the current directory (this file) and must supply a valid command for that `maskfile` (`maskfile_command`) in order to test the changes you've made to `mask`. Since you can only test against this `maskfile` for now, you can add subcommands to the bottom and run against those instead of running one of the existing commands.
 
 **EXAMPLE:** `mask run "test -h"` - outputs the help info of this `test` command
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,7 @@
 use std::env;
 use std::path::Path;
 
-use clap::{
-    crate_authors, crate_description, crate_name, crate_version, App, AppSettings, Arg, ArgMatches,
-    SubCommand,
-};
+use clap::{crate_name, crate_version, App, AppSettings, Arg, ArgMatches, SubCommand};
 use colored::*;
 
 use mask::command::Command;
@@ -15,8 +12,6 @@ fn main() {
         .setting(AppSettings::VersionlessSubcommands)
         .setting(AppSettings::SubcommandRequired)
         .version(crate_version!())
-        .author(crate_authors!())
-        .about(crate_description!())
         .arg(custom_maskfile_path_arg());
 
     let (maskfile, maskfile_path) = find_maskfile();


### PR DESCRIPTION
Showing the author and description info of mask is a bit odd every time someone runs help...
