### PR TITLE
Add support for type=number in option flags for numerical validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,33 @@ Important to note that `mask` auto injects a very common `boolean` flag called `
     * desc: Which port to serve on
 
 ~~~sh
-# Set a fallback port
-PORT=${port:-8080}
+PORT=${port:-8080} # Set a fallback port if not supplied
 
 if [[ "$verbose" == "true" ]]; then
     echo "Starting an http server on PORT: $PORT"
 fi
 python -m SimpleHTTPServer $PORT
+~~~
+```
+
+You can also make your flag expect a numerical value by setting its `type` to `number`. This means `mask` will automatically validate it as a number for you. If it fails to validate, `mask` will exit with a helpful error message.
+
+**Example:**
+
+```markdown
+## purchase (price)
+
+> Calculate the total price of something.
+
+**OPTIONS**
+* tax
+    * flags: -t --tax
+    * type: number
+    * desc: What's the tax?
+
+~~~sh
+TAX=${tax:-1} # Fallback to 1 if not supplied
+echo "Total: $(($price * $TAX))"
 ~~~
 ```
 
@@ -341,7 +361,6 @@ This variable is an absolute path to the maskfile's parent directory. Having the
 
 * [ ] [Optional (non-required) positional arguments][2]
 * [ ] [Infinite positional args](https://github.com/jakedeichert/mask/issues/4)
-* [ ] [Option flag `number` type for input validation purposes](https://github.com/jakedeichert/mask/issues/3)
 
 
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -36,6 +36,7 @@ impl Command {
                 long: "verbose".to_string(),
                 multiple: false,
                 takes_value: false,
+                validate_as_number: false,
                 val: "".to_string(),
             });
         }
@@ -62,10 +63,11 @@ impl RequiredArg {
 pub struct OptionFlag {
     pub name: String,
     pub desc: String,
-    pub short: String,     // v        (used as -v)
-    pub long: String,      // verbose  (used as --verbose)
-    pub multiple: bool,    // Can it have multiple values? (-vvv OR -i one -i two)
-    pub takes_value: bool, // Does it take a value? (-i value)
+    pub short: String,            // v        (used as -v)
+    pub long: String,             // verbose  (used as --verbose)
+    pub multiple: bool,           // Can it have multiple values? (-vvv OR -i one -i two)
+    pub takes_value: bool,        // Does it take a value? (-i value)
+    pub validate_as_number: bool, // Should we validate it as a number?
     pub val: String,
 }
 
@@ -78,6 +80,7 @@ impl OptionFlag {
             long: "".to_string(),
             multiple: false,
             takes_value: false,
+            validate_as_number: false,
             val: "".to_string(),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,11 +149,25 @@ fn get_command_options(mut cmd: Command, matches: &ArgMatches) -> Command {
     for flag in &mut cmd.option_flags {
         flag.val = if flag.takes_value {
             // Extract the value
-            matches
+            let raw_value = matches
                 .value_of(flag.name.clone())
                 .or(Some(""))
                 .unwrap()
-                .to_string()
+                .to_string();
+
+            if flag.validate_as_number {
+                // Try converting to an integer or float to validate it
+                if raw_value.parse::<isize>().is_err() && raw_value.parse::<f32>().is_err() {
+                    eprintln!(
+                        "{} flag `{}` expects a numerical value",
+                        "ERROR:".red(),
+                        flag.name
+                    );
+                    std::process::exit(1);
+                }
+            }
+
+            raw_value
         } else {
             // Check if the boolean flag is present and set to "true".
             // It's a string since it's set as an environment variable.

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,7 +155,7 @@ fn get_command_options(mut cmd: Command, matches: &ArgMatches) -> Command {
                 .unwrap()
                 .to_string();
 
-            if flag.validate_as_number {
+            if flag.validate_as_number && raw_value != "" {
                 // Try converting to an integer or float to validate it
                 if raw_value.parse::<isize>().is_err() && raw_value.parse::<f32>().is_err() {
                     eprintln!(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -81,10 +81,13 @@ pub fn build_command_structure(maskfile_contents: String) -> Command {
                     let val = config_split.next().unwrap_or("").trim();
                     match param {
                         "desc" => current_option_flag.desc = val.to_string(),
-                        // TODO: allow "number" type for input validation purposes https://github.com/jakedeichert/mask/issues/3
                         "type" => {
-                            if val == "string" {
+                            if val == "string" || val == "number" {
                                 current_option_flag.takes_value = true;
+                            }
+
+                            if val == "number" {
+                                current_option_flag.validate_as_number = true;
                             }
                         }
                         // Parse out the short and long flag names

--- a/tests/arguments_and_flags_test.rs
+++ b/tests/arguments_and_flags_test.rs
@@ -187,6 +187,30 @@ echo "This shouldn't render"
             )))
             .failure();
     }
+
+    #[test]
+    fn ignores_the_option_if_not_supplied() {
+        let (_temp, maskfile_path) = common::maskfile(
+            r#"
+## nooption
+
+**OPTIONS**
+* val
+    * flags: --val
+    * type: number
+
+~~~bash
+echo "No arg this time"
+~~~
+"#,
+        );
+
+        common::run_mask(&maskfile_path)
+            .cli("nooption")
+            .assert()
+            .stdout(contains("No arg this time"))
+            .success();
+    }
 }
 
 mod version_flag {

--- a/tests/arguments_and_flags_test.rs
+++ b/tests/arguments_and_flags_test.rs
@@ -1,5 +1,6 @@
 use assert_cmd::prelude::*;
 use clap::{crate_name, crate_version};
+use colored::*;
 use predicates::str::contains;
 
 mod common;
@@ -83,6 +84,109 @@ fi
         .assert()
         .stdout(contains("Starting an http server on PORT: 1234"))
         .success();
+}
+
+mod numerical_option_flag {
+    use super::*;
+
+    #[test]
+    fn properly_validates_flag_with_type_number() {
+        let (_temp, maskfile_path) = common::maskfile(
+            r#"
+## integer
+
+**OPTIONS**
+* val
+    * flags: --val
+    * type: number
+
+~~~bash
+echo "Value: $val"
+~~~
+"#,
+        );
+
+        common::run_mask(&maskfile_path)
+            .cli("integer --val 1111112222")
+            .assert()
+            .stdout(contains("Value: 1111112222"))
+            .success();
+    }
+
+    #[test]
+    fn properly_validates_negative_numbers() {
+        let (_temp, maskfile_path) = common::maskfile(
+            r#"
+## negative
+
+**OPTIONS**
+* val
+    * flags: --val
+    * type: number
+
+~~~bash
+echo "Value: $val"
+~~~
+"#,
+        );
+
+        common::run_mask(&maskfile_path)
+            .cli("negative --val -123")
+            .assert()
+            .stdout(contains("Value: -123"))
+            .success();
+    }
+
+    #[test]
+    fn properly_validates_decimal_numbers() {
+        let (_temp, maskfile_path) = common::maskfile(
+            r#"
+## decimal
+
+**OPTIONS**
+* val
+    * flags: --val
+    * type: number
+
+~~~bash
+echo "Value: $val"
+~~~
+"#,
+        );
+
+        common::run_mask(&maskfile_path)
+            .cli("decimal --val 123.3456789")
+            .assert()
+            .stdout(contains("Value: 123.3456789"))
+            .success();
+    }
+
+    #[test]
+    fn errors_when_value_is_not_a_number() {
+        let (_temp, maskfile_path) = common::maskfile(
+            r#"
+## notanumber
+
+**OPTIONS**
+* val
+    * flags: --val
+    * type: number
+
+~~~bash
+echo "This shouldn't render"
+~~~
+"#,
+        );
+
+        common::run_mask(&maskfile_path)
+            .cli("notanumber --val a234")
+            .assert()
+            .stderr(contains(format!(
+                "{} flag `val` expects a numerical value",
+                "ERROR:".red()
+            )))
+            .failure();
+    }
 }
 
 mod version_flag {

--- a/tests/subcommands_test.rs
+++ b/tests/subcommands_test.rs
@@ -62,8 +62,7 @@ mod when_entering_negative_numbers {
     fn allows_entering_negative_numbers_as_values() {
         let (_temp, maskfile_path) = common::maskfile(
             r#"
-## math
-### math add (a) (b)
+## add (a) (b)
 ~~~bash
 echo $(($a + $b))
 ~~~
@@ -71,7 +70,7 @@ echo $(($a + $b))
         );
 
         common::run_mask(&maskfile_path)
-            .cli("math add -1 -3")
+            .cli("add -1 -3")
             .assert()
             .stdout(contains("-4"))
             .success();
@@ -81,8 +80,7 @@ echo $(($a + $b))
     fn allows_entering_negative_numbers_as_flag_values() {
         let (_temp, maskfile_path) = common::maskfile(
             r#"
-## math
-### math add
+## add
 
 **OPTIONS**
 * a
@@ -99,7 +97,7 @@ echo $(($a + $b))
         );
 
         common::run_mask(&maskfile_path)
-            .cli("math add --a -33 --b 17")
+            .cli("add --a -33 --b 17")
             .assert()
             .stdout(contains("-16"))
             .success();


### PR DESCRIPTION
<!--
  Please review our Contribution Guidelines (CONTRIBUTING.md) before creating
  an issue or submitting a PR 🙌
-->


### Which issue does this fix?
<!-- Replace {ISSUE} with the issue number you've fixed. -->

Closes #3 



### Describe the solution
<!-- Add some details about what you did to fix the issue. -->
If an option's flag has `type: number`, we now try to parse it as an integer or float for validation. If both fail, we exit with an error message.


### How to test
<!-- Describe how to test this PR and check the boxes if you added tests -->

- [ ] Added unit tests
- [x] Added integration tests



### Types of changes
<!-- What types of changes does your code introduce? -->

- [ ] Bug fix               <!-- non-breaking change which fixes an issue -->
- [x] New feature           <!-- non-breaking change which adds functionality -->
- [ ] Breaking change       <!-- fix or feature that would cause existing functionality to not work as expected -->
