### PR TITLE
Allow any shell executor that supports -c evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,7 @@ On top of shell/bash scripts, `mask` also supports using node, python, ruby and 
 
 > An example shell script
 
-Valid lang codes: sh, bash, zsh, fish
-The fallback is sh for unknown language codes.
+Valid lang codes: sh, bash, zsh, fish... any shell that supports -c
 
 ~~~zsh
 echo "Hello, $name!"

--- a/src/command.rs
+++ b/src/command.rs
@@ -57,7 +57,7 @@ impl Script {
     }
 
     pub fn has_script(&self) -> bool {
-        self.source != ""
+        self.source != "" && self.executor != ""
     }
 }
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -67,7 +67,7 @@ fn prepare_command_without_init_script(cmd: &Command) -> process::Command {
             child.arg("-r").arg(source);
             child
         }
-        // Any shell script that uses -c (sh, bash, zsh, fish, dash, etc...)
+        // Any other executor that supports -c (sh, bash, zsh, fish, dash, etc...)
         _ => {
             let mut child = process::Command::new(executor);
             child.arg("-c").arg(source);
@@ -84,7 +84,7 @@ fn prepare_command_with_init_script(init_script: Script, cmd: &Command) -> proce
         "py" | "python" => run_with_init_script(&init_script, &cmd, "python -c"),
         "rb" | "ruby" => run_with_init_script(&init_script, &cmd, "ruby -e"),
         "php" => run_with_init_script(&init_script, &cmd, "php -r"),
-        // Any other executor that uses -c (sh, bash, zsh, fish, dash, etc...)
+        // Any other executor that supports -c (sh, bash, zsh, fish, dash, etc...)
         _ => run_with_init_script(&init_script, &cmd, &format!("{} -c", executor)),
     }
 }

--- a/tests/arguments_and_flags_test.rs
+++ b/tests/arguments_and_flags_test.rs
@@ -86,6 +86,55 @@ fi
         .success();
 }
 
+mod when_entering_negative_numbers {
+    use super::*;
+
+    #[test]
+    fn allows_entering_negative_numbers_as_values() {
+        let (_temp, maskfile_path) = common::maskfile(
+            r#"
+## add (a) (b)
+~~~bash
+echo $(($a + $b))
+~~~
+"#,
+        );
+
+        common::run_mask(&maskfile_path)
+            .cli("add -1 -3")
+            .assert()
+            .stdout(contains("-4"))
+            .success();
+    }
+
+    #[test]
+    fn allows_entering_negative_numbers_as_flag_values() {
+        let (_temp, maskfile_path) = common::maskfile(
+            r#"
+## add
+
+**OPTIONS**
+* a
+    * flags: --a
+    * type: string
+* b
+    * flags: --b
+    * type: string
+
+~~~bash
+echo $(($a + $b))
+~~~
+"#,
+        );
+
+        common::run_mask(&maskfile_path)
+            .cli("add --a -33 --b 17")
+            .assert()
+            .stdout(contains("-16"))
+            .success();
+    }
+}
+
 mod numerical_option_flag {
     use super::*;
 

--- a/tests/supported_runtimes_test.rs
+++ b/tests/supported_runtimes_test.rs
@@ -1,22 +1,60 @@
 use assert_cmd::prelude::*;
+use colored::*;
 use predicates::str::contains;
 
 mod common;
 use common::MaskCommandExt;
 
 #[test]
+fn errors_when_no_lang_code_is_specified() {
+    let (_temp, maskfile_path) = common::maskfile(
+        r#"
+## missing
+~~~
+echo "this won't do anything..."
+~~~
+"#,
+    );
+
+    common::run_mask(&maskfile_path)
+        .command("missing")
+        .assert()
+        .code(1)
+        .stderr(contains(format!(
+            "{} Command script requires a lang code which determines which executor to use.",
+            "ERROR:".red()
+        )))
+        .failure();
+}
+
+#[test]
+fn sh() {
+    let (_temp, maskfile_path) = common::maskfile(
+        r#"
+## sh
+~~~sh
+echo Hello, $name!
+~~~
+"#,
+    );
+
+    common::run_mask(&maskfile_path)
+        .command("sh")
+        .env("name", "World")
+        .assert()
+        .stdout(contains("Hello, World!"))
+        .success();
+}
+
+#[test]
 fn bash() {
     let (_temp, maskfile_path) = common::maskfile(
-        "
-# Integration tests
-
+        r#"
 ## bash
-
-```bash
+~~~bash
 echo Hello, $name!
-```
-
-",
+~~~
+"#,
     );
 
     common::run_mask(&maskfile_path)
@@ -30,17 +68,13 @@ echo Hello, $name!
 #[test]
 fn node() {
     let (_temp, maskfile_path) = common::maskfile(
-        "
-# Integration tests
-
+        r#"
 ## node
-
-```js
+~~~js
 const { name } = process.env;
 console.log(`Hello, ${name}!`);
-```
-
-",
+~~~
+"#,
     );
 
     common::run_mask(&maskfile_path)
@@ -55,18 +89,12 @@ console.log(`Hello, ${name}!`);
 fn python() {
     let (_temp, maskfile_path) = common::maskfile(
         r#"
-# Integration tests
-
 ## python
-
-```py
+~~~py
 import os
-
 name = os.getenv("name", "WORLD")
-
 print("Hello, " + name + "!")
-```
-
+~~~
 "#,
     );
 
@@ -82,16 +110,11 @@ print("Hello, " + name + "!")
 fn ruby() {
     let (_temp, maskfile_path) = common::maskfile(
         r#"
-# Integration tests
-
 ## ruby
-
-```ruby
+~~~ruby
 name = ENV["name"] || "WORLD"
-
 puts "Hello, #{name}!"
-```
-
+~~~
 "#,
     );
 
@@ -107,16 +130,12 @@ puts "Hello, #{name}!"
 fn php() {
     let (_temp, maskfile_path) = common::maskfile(
         r#"
-# Integration tests
-
 ## php
-
-```php
+~~~php
 $name = getenv("name") ?: "WORLD";
 
 echo "Hello, " . $name . "!\n";
-```
-
+~~~
 "#,
     );
 


### PR DESCRIPTION
### Describe the solution
Mask now allows any executor to be used as long as its markdown lang code matches its actual command name. 

Other changes:
* Error when chosen command doesn't have a script
* Error when chosen command script doesn't have a lang code to determine the executor



### How to test
<!-- Describe how to test this PR and check the box if you added tests -->

- [x] Added tests



### Types of changes
<!-- What types of changes does your code introduce? -->

- [ ] Bug fix               <!-- non-breaking change which fixes an issue -->
- [x] New feature           <!-- non-breaking change which adds functionality -->
- [x] Breaking change       <!-- fix or feature that would cause existing functionality to not work as expected -->
