### PR TITLE
feat(windows) powershell and batch support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,10 @@ jobs:
         run: cargo build --tests --frozen
       - name: Make mask available globally (windows)
         run: copy ./target/debug/mask.exe ~/.cargo/bin/
-        if: matrix.platform == windows-latest
+        if: matrix.platform == 'windows-latest'
       - name: Make mask available globally (linux)
         run: cp ./target/debug/mask ~/.cargo/bin
-        if: matrix.platform == ubuntu-latest
+        if: matrix.platform == 'ubuntu-latest'
       - name: Run tests
         run: cargo test --frozen
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubunut-latest, windows-latest]
+        platform: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout master
         uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,12 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Build
-    runs-on: ubuntu-latest
+    name: ${{ matrix.platform }}-build
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubunut-latest, windows-latest]
     steps:
       - name: Checkout master
         uses: actions/checkout@master
@@ -15,8 +19,12 @@ jobs:
         run: cargo build --release --frozen
 
   test:
-    name: Test
-    runs-on: ubuntu-latest
+    name: ${{ matrix.platform }}-test
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout master
         uses: actions/checkout@master
@@ -28,8 +36,12 @@ jobs:
         run: cargo fetch
       - name: Build in test mode
         run: cargo build --tests --frozen
-      - name: Make mask available globally for certain test suites that depend on it
-        run: cp ./target/debug/mask /usr/share/rust/.cargo/bin
+      - name: Make mask available globally (windows)
+        run: copy ./target/debug/mask.exe ~/.cargo/bin/
+        if: matrix.platform == windows-latest
+      - name: Make mask available globally (linux)
+        run: cp ./target/debug/mask ~/.cargo/bin
+        if: matrix.platform == ubuntu-latest
       - name: Run tests
         run: cargo test --frozen
 

--- a/maskfile.md
+++ b/maskfile.md
@@ -27,18 +27,18 @@ else
 fi
 ~~~
 
-}
 ~~~powershell
-param (
-    [string] $watch = $env:watch | $env:w
-)
-$cargo_cmd = "cargo run -- $env:markfile_command"
+$watch = $env:watch
+$w = $env:w
+$maskfile_command = $env:maskfile_command
+
+$cargo_cmd = "cargo run -- $maskfile_command"
 $extra_args = "--exts rs --restart $cargo_cmd"
 
-if ($watch == "true") {
-    watchexec $extra_args
+if ($watch -Or $w) {
+    Start-Process watchexec -ArgumentList $extra_args -NoNewWindow -PassThru
 } else {
-    cargo run -- $env:markfile_command
+    cargo run -- $maskfile_command
 }
 ~~~
 
@@ -64,7 +64,7 @@ cargo install --force --path .
 ~~~
 
 ~~~powershell
-cargo install --path . --force
+[Diagnostics.Process]::Start("cargo", "install --force --path .").WaitForExit()
 ~~~
 
 
@@ -100,10 +100,14 @@ echo "Tests passed!"
 ~~~powershell
 $verbose = $env:verbose 
 $file = $env:file
+$f = $env:f
 $extra_args = ""
 
+if ($f) {
+    $file = $f
+}
 
-if ($verbose -eq "true") {
+if ($verbose) {
     $extra_args = "-- --nocapture --test-threads=1"
 }
 
@@ -152,11 +156,10 @@ fi
 ~~~
 
 ~~~powershell
-param (
-    [string] $c   
-)
+$check = $env:check
+$c = $env:c
 
-if ($env:check -eq "true" -or $c -eq "true") {
+if ($env:check -or $c) {
     cargo fmt --all -- --check
 } else {
     cargo fmt

--- a/maskfile.md
+++ b/maskfile.md
@@ -27,6 +27,20 @@ else
 fi
 ~~~
 
+}
+~~~powershell
+param (
+    [string] $watch = $env:watch | $env:w
+)
+$cargo_cmd = "cargo run -- $env:markfile_command"
+$extra_args = "--exts rs --restart $cargo_cmd"
+
+if ($watch == "true") {
+    watchexec $extra_args
+} else {
+    cargo run -- $env:markfile_command
+}
+~~~
 
 
 ## build
@@ -37,7 +51,9 @@ fi
 cargo build --release
 ~~~
 
-
+~~~powershell
+cargo build --release
+~~~
 
 ## link
 
@@ -47,6 +63,9 @@ cargo build --release
 cargo install --force --path .
 ~~~
 
+~~~powershell
+cargo install --path . --force
+~~~
 
 
 ## test
@@ -78,7 +97,25 @@ fi
 echo "Tests passed!"
 ~~~
 
+~~~powershell
+$verbose = $env:verbose 
+$file = $env:file
+$extra_args = ""
 
+
+if ($verbose -eq "true") {
+    $extra_args = "-- --nocapture --test-threads=1"
+}
+
+Write-Output "Running tests..."
+if (!$file) {
+    cargo test $extra_args
+} else {
+    cargo test --test $file $extra_args
+}
+Write-Output "Tests passed!"
+
+~~~
 
 ## deps
 
@@ -92,6 +129,9 @@ echo "Tests passed!"
 cargo update
 ~~~
 
+~~~powershell
+cargo update
+~~~
 
 
 ## format
@@ -111,6 +151,17 @@ else
 fi
 ~~~
 
+~~~powershell
+param (
+    [string] $c   
+)
+
+if ($env:check -eq "true" -or $c -eq "true") {
+    cargo fmt --all -- --check
+} else {
+    cargo fmt
+}
+~~~
 
 
 ## lint
@@ -118,5 +169,9 @@ fi
 > Lint the project with clippy
 
 ~~~bash
+cargo clippy
+~~~
+
+~~~powershell
 cargo clippy
 ~~~

--- a/maskfile.md
+++ b/maskfile.md
@@ -33,7 +33,7 @@ fi
 param (
     $maskfile_command = $env:maskfile_command,
     $watch = $env:watch,
-    $w = $env:w
+    $w
 )
 
 if ($w) {
@@ -108,7 +108,7 @@ echo "Tests passed!"
 ~~~powershell
 param (
     $file = $env:file,
-    $f = $env:f
+    $f
 )
 
 $extra_args = ""
@@ -168,7 +168,7 @@ fi
 ~~~powershell
 param (
     $check = $env:check,
-    $c = $env:c
+    $c
 )
 
 if ($c) {

--- a/maskfile.md
+++ b/maskfile.md
@@ -32,13 +32,8 @@ fi
 ~~~powershell
 param (
     $maskfile_command = $env:maskfile_command,
-    $watch = $env:watch,
-    $w
+    $watch = $env:watch
 )
-
-if ($w) {
-    $watch = $w
-}
 
 $cargo_cmd = "cargo run -- $maskfile_command"
 $extra_args = "--exts rs --restart $cargo_cmd"
@@ -107,16 +102,11 @@ echo "Tests passed!"
 
 ~~~powershell
 param (
-    $file = $env:file,
-    $f
+    $file = $env:file
 )
 
 $extra_args = ""
 $verbose = $env:verbose 
-
-if ($f) {
-    $file = $f
-}
 
 if ($verbose) {
     $extra_args = "-- --nocapture --test-threads=1"
@@ -167,13 +157,8 @@ fi
 
 ~~~powershell
 param (
-    $check = $env:check,
-    $c
+    $check = $env:check
 )
-
-if ($c) {
-    $check = $c
-}
 
 if ($check) {
     cargo fmt --all -- --check

--- a/maskfile.md
+++ b/maskfile.md
@@ -27,6 +27,8 @@ else
 fi
 ~~~
 
+**Note:** On Windows platforms, `mask` falls back to running `powershell` code blocks.
+
 ~~~powershell
 param (
     $maskfile_command = $env:maskfile_command,

--- a/maskfile.md
+++ b/maskfile.md
@@ -118,7 +118,6 @@ if (!$file) {
     cargo test --test $file $extra_args
 }
 Write-Output "Tests passed!"
-
 ~~~
 
 ## deps

--- a/maskfile.md
+++ b/maskfile.md
@@ -28,14 +28,20 @@ fi
 ~~~
 
 ~~~powershell
-$watch = $env:watch
-$w = $env:w
-$maskfile_command = $env:maskfile_command
+param (
+    $maskfile_command = $env:maskfile_command,
+    $watch = $env:watch,
+    $w = $env:w
+)
+
+if ($w) {
+    $watch = $w
+}
 
 $cargo_cmd = "cargo run -- $maskfile_command"
 $extra_args = "--exts rs --restart $cargo_cmd"
 
-if ($watch -Or $w) {
+if ($watch) {
     Start-Process watchexec -ArgumentList $extra_args -NoNewWindow -PassThru
 } else {
     cargo run -- $maskfile_command
@@ -98,10 +104,13 @@ echo "Tests passed!"
 ~~~
 
 ~~~powershell
-$verbose = $env:verbose 
-$file = $env:file
-$f = $env:f
+param (
+    $file = $env:file,
+    $f = $env:f
+)
+
 $extra_args = ""
+$verbose = $env:verbose 
 
 if ($f) {
     $file = $f
@@ -155,10 +164,16 @@ fi
 ~~~
 
 ~~~powershell
-$check = $env:check
-$c = $env:c
+param (
+    $check = $env:check,
+    $c = $env:c
+)
 
-if ($env:check -or $c) {
+if ($c) {
+    $check = $c
+}
+
+if ($check) {
     cargo fmt --all -- --check
 } else {
     cargo fmt

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -53,6 +53,12 @@ fn prepare_command(cmd: &Command) -> process::Command {
             child.arg("-r").arg(source);
             child
         }
+        #[cfg(windows)]
+        "cmd" | "batch" => {
+            let mut child = process::Command::new("cmd.exe");
+            child.arg("/c").arg(source);
+            child
+        }
         // Any other executor that supports -c (sh, bash, zsh, fish, dash, etc...)
         _ => {
             let mut child = process::Command::new(executor);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -29,7 +29,7 @@ pub fn build_command_structure(maskfile_contents: String) -> Command {
                     }
                     #[cfg(not(windows))]
                     Tag::CodeBlock(lang_code) => {
-                        if lang_code.to_string() != "powershell" {
+                        if lang_code.to_string() != "powershell" | "batch" | "cmd" {
                             current_command.script.executor = lang_code.to_string();
                         }
                     }
@@ -59,6 +59,13 @@ pub fn build_command_structure(maskfile_contents: String) -> Command {
                 Tag::BlockQuote => {
                     current_command.desc = text.clone();
                 }
+                #[cfg(not(windows))]
+                Tag::CodeBlock(lang_code) => {
+                    if lang_code.to_string() != "powershell" | "batch" | "cmd" {
+                        current_command.script.source = text.to_string();
+                    }
+                }
+                #[cfg(windows)]
                 Tag::CodeBlock(_) => {
                     current_command.script.source = text.to_string();
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -29,7 +29,10 @@ pub fn build_command_structure(maskfile_contents: String) -> Command {
                     }
                     #[cfg(not(windows))]
                     Tag::CodeBlock(lang_code) => {
-                        if lang_code.to_string() != "powershell" | "batch" | "cmd" {
+                        if lang_code.to_string() != "powershell"
+                            || lang_code.to_string() != "batch"
+                            || lang_code.to_string() != "cmd"
+                        {
                             current_command.script.executor = lang_code.to_string();
                         }
                     }
@@ -61,7 +64,10 @@ pub fn build_command_structure(maskfile_contents: String) -> Command {
                 }
                 #[cfg(not(windows))]
                 Tag::CodeBlock(lang_code) => {
-                    if lang_code.to_string() != "powershell" | "batch" | "cmd" {
+                    if lang_code.to_string() != "powershell"
+                        || lang_code.to_string() != "batch"
+                        || lang_code.to_string() != "cmd"
+                    {
                         current_command.script.source = text.to_string();
                     }
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -27,6 +27,13 @@ pub fn build_command_structure(maskfile_contents: String) -> Command {
                         }
                         current_command = Command::new(heading_level as u8);
                     }
+                    #[cfg(not(windows))]
+                    Tag::CodeBlock(lang_code) => {
+                        if lang_code.to_string() != "powershell" {
+                            current_command.script.executor = lang_code.to_string();
+                        }
+                    }
+                    #[cfg(windows)]
                     Tag::CodeBlock(lang_code) => {
                         current_command.script.executor = lang_code.to_string();
                     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -30,8 +30,8 @@ pub fn build_command_structure(maskfile_contents: String) -> Command {
                     #[cfg(not(windows))]
                     Tag::CodeBlock(lang_code) => {
                         if lang_code.to_string() != "powershell"
-                            || lang_code.to_string() != "batch"
-                            || lang_code.to_string() != "cmd"
+                            && lang_code.to_string() != "batch"
+                            && lang_code.to_string() != "cmd"
                         {
                             current_command.script.executor = lang_code.to_string();
                         }
@@ -65,8 +65,8 @@ pub fn build_command_structure(maskfile_contents: String) -> Command {
                 #[cfg(not(windows))]
                 Tag::CodeBlock(lang_code) => {
                     if lang_code.to_string() != "powershell"
-                        || lang_code.to_string() != "batch"
-                        || lang_code.to_string() != "cmd"
+                        && lang_code.to_string() != "batch"
+                        && lang_code.to_string() != "cmd"
                     {
                         current_command.script.source = text.to_string();
                     }

--- a/tests/arguments_and_flags_test.rs
+++ b/tests/arguments_and_flags_test.rs
@@ -17,6 +17,10 @@ fn positional_arguments() {
 ~~~bash
 echo "Testing $test_case in $file"
 ~~~
+
+~~~powershell
+Write-Output "Testing $env:test_case in $env:file"
+~~~
 "#,
     );
 
@@ -64,6 +68,20 @@ else
     echo $PORT
 fi
 ```
+
+```powershell
+param (
+    [string]
+    [Parameter(Mandatory = $false)]
+    $port = $env:port
+)
+
+if ($env:verbose -eq "true") {
+    Write-Output "Starting an http server on PORT: $port"
+} else {
+    Write-Output $port
+}
+```
 "#,
     );
 
@@ -97,6 +115,12 @@ mod when_entering_negative_numbers {
 ~~~bash
 echo $(($a + $b))
 ~~~
+
+~~~powershell
+$sum = "$([int]$env:a + [int]$env:b)"
+
+Write-Host $sum
+~~~
 "#,
         );
 
@@ -123,6 +147,12 @@ echo $(($a + $b))
 
 ~~~bash
 echo $(($a + $b))
+~~~
+
+~~~powershell
+$sum = "$([int]$env:a + $env:b)"
+
+Write-Output $sum
 ~~~
 "#,
         );
@@ -152,6 +182,11 @@ mod numerical_option_flag {
 ~~~bash
 echo "Value: $val"
 ~~~
+
+~~~powershell
+$in = $env:val
+Write-Output "Value: $in"
+~~~
 "#,
         );
 
@@ -175,6 +210,11 @@ echo "Value: $val"
 
 ~~~bash
 echo "Value: $val"
+~~~
+
+~~~powershell
+$in = [int]$env:val
+Write-Output "Value: $in"
 ~~~
 "#,
         );
@@ -200,6 +240,11 @@ echo "Value: $val"
 ~~~bash
 echo "Value: $val"
 ~~~
+
+~~~powershell
+[Double]$in = [Double]$env:val
+Write-Output "Value: $in"
+~~~
 "#,
         );
 
@@ -223,6 +268,10 @@ echo "Value: $val"
 
 ~~~bash
 echo "This shouldn't render"
+~~~
+
+~~~powershell
+Write-Output "This shouldn't render"
 ~~~
 "#,
         );
@@ -250,6 +299,10 @@ echo "This shouldn't render"
 
 ~~~bash
 echo "No arg this time"
+~~~
+
+~~~powershell
+Write-Output "No arg this time"
 ~~~
 "#,
         );

--- a/tests/arguments_and_flags_test.rs
+++ b/tests/arguments_and_flags_test.rs
@@ -19,7 +19,12 @@ echo "Testing $test_case in $file"
 ~~~
 
 ~~~powershell
-Write-Output "Testing $env:test_case in $env:file"
+param (
+    $test_case = $env:test_case,
+    $file = $env:file
+)
+
+Write-Output "Testing $test_case in $file"
 ~~~
 "#,
     );
@@ -76,7 +81,7 @@ param (
     $port = $env:port
 )
 
-if ($env:verbose -eq "true") {
+if ($env:verbose) {
     Write-Output "Starting an http server on PORT: $port"
 } else {
     Write-Output $port
@@ -117,7 +122,11 @@ echo $(($a + $b))
 ~~~
 
 ~~~powershell
-$sum = "$([int]$env:a + [int]$env:b)"
+param (
+    [int]$a = $env:a,
+    [int]$b = $env:b
+)
+$sum = "$($a + $b)"
 
 Write-Host $sum
 ~~~
@@ -150,7 +159,11 @@ echo $(($a + $b))
 ~~~
 
 ~~~powershell
-$sum = "$([int]$env:a + $env:b)"
+param (
+    [int]$a = $env:a,
+    [int]$b = $env:b
+)
+$sum = "$($a + $b)"
 
 Write-Output $sum
 ~~~
@@ -184,7 +197,9 @@ echo "Value: $val"
 ~~~
 
 ~~~powershell
-$in = $env:val
+param (
+    $in = $env:val
+)
 Write-Output "Value: $in"
 ~~~
 "#,
@@ -213,7 +228,10 @@ echo "Value: $val"
 ~~~
 
 ~~~powershell
-$in = [int]$env:val
+param (
+    [int]$in = $env:val
+)
+
 Write-Output "Value: $in"
 ~~~
 "#,
@@ -242,7 +260,9 @@ echo "Value: $val"
 ~~~
 
 ~~~powershell
-[Double]$in = [Double]$env:val
+param (
+    [Double]$in = $env:val
+)
 Write-Output "Value: $in"
 ~~~
 "#,

--- a/tests/arguments_and_flags_test.rs
+++ b/tests/arguments_and_flags_test.rs
@@ -128,7 +128,7 @@ param (
 )
 $sum = "$($a + $b)"
 
-Write-Host $sum
+Write-Output $sum
 ~~~
 "#,
         );

--- a/tests/env_vars_test.rs
+++ b/tests/env_vars_test.rs
@@ -20,10 +20,22 @@ mod env_var_mask {
 $MASK test
 ~~~
 
+~~~powershell
+$path = $env:MASK.replace("\\?\", "")
+$pos = $path.IndexOf(" ");
+$arglist = $path.Substring($pos + 1);
+
+Start-Process mask.exe -ArgumentList "$arglist test" -wait -NoNewWindow -PassThru
+~~~
+
 ## test
 
 ~~~bash
 echo "tests passed"
+~~~
+
+~~~powershell
+Write-Output "tests passed"
 ~~~
 "#,
         );
@@ -45,15 +57,26 @@ echo "tests passed"
 ~~~bash
 echo "mask = $MASK"
 ~~~
+
+~~~powershell
+$var = "$env:mask /"
+Write-Output "mask = $var"
+~~~
+
 "#,
         );
+
+        #[cfg(windows)]
+        let predicate = contains("mask = mask --maskfile \\");
+        #[cfg(not(windows))]
+        let predicate = contains("mask = mask --maskfile /");
 
         common::run_mask(&maskfile_path)
             .current_dir(".github")
             .command("run")
             .assert()
             // Absolute maskfile path starts with /
-            .stdout(contains("mask = mask --maskfile /"))
+            .stdout(predicate)
             // And ends with maskfile.md
             .stdout(contains("maskfile.md"))
             .success();
@@ -72,6 +95,11 @@ mod env_var_maskfile_dir {
 
 ~~~bash
 echo "maskfile_dir = $MASKFILE_DIR"
+~~~
+
+~~~powershell
+$var = $env:maskfile_dir
+Write-Output "maskfile_dir = /$var"
 ~~~
 "#,
         );

--- a/tests/env_vars_test.rs
+++ b/tests/env_vars_test.rs
@@ -59,7 +59,10 @@ echo "mask = $MASK"
 ~~~
 
 ~~~powershell
-$var = "$env:mask /"
+param (
+    $var = "$env:mask /"
+)
+
 Write-Output "mask = $var"
 ~~~
 
@@ -98,7 +101,10 @@ echo "maskfile_dir = $MASKFILE_DIR"
 ~~~
 
 ~~~powershell
-$var = $env:maskfile_dir
+param (
+    $var = $env:maskfile_dir
+)
+
 Write-Output "maskfile_dir = /$var"
 ~~~
 "#,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -128,6 +128,10 @@ mod exits_with_the_child_process_status_code {
 ~~~sh
 exit 0
 ~~~
+
+~~~powershell
+Exit 0
+~~~
 "#,
         );
 
@@ -147,6 +151,10 @@ exit 0
 ~~~sh
 exit 1
 ~~~
+
+~~~powershell
+Exit 1
+~~~
 "#,
         );
 
@@ -165,6 +173,10 @@ exit 1
 
 ~~~sh
 exit 2
+~~~
+
+~~~powershell
+Exit 2
 ~~~
 "#,
         );

--- a/tests/subcommands_test.rs
+++ b/tests/subcommands_test.rs
@@ -22,6 +22,10 @@ fn positional_arguments() {
 echo "Starting service $service_name"
 ~~~
 
+~~~powershell
+Write-Output "Starting service $env:service_name"
+~~~
+
 ### services stop (service_name)
 
 > Stop a service.
@@ -48,13 +52,17 @@ fn exits_with_error_when_missing_subcommand() {
 "#,
     );
 
+    #[cfg(not(windows))]
+    let predicate =
+        contains("error: 'mask service' requires a subcommand, but one was not provided");
+    #[cfg(windows)]
+    let predicate =
+        contains("error: 'mask.exe service' requires a subcommand, but one was not provided");
     common::run_mask(&maskfile_path)
         .command("service")
         .assert()
         .code(1)
-        .stderr(contains(
-            "error: 'mask service' requires a subcommand, but one was not provided",
-        ))
+        .stderr(predicate)
         .failure();
 }
 

--- a/tests/subcommands_test.rs
+++ b/tests/subcommands_test.rs
@@ -23,7 +23,11 @@ echo "Starting service $service_name"
 ~~~
 
 ~~~powershell
-Write-Output "Starting service $env:service_name"
+param(
+    $service_name = $env:service_name
+)
+
+Write-Output "Starting service $service_name"
 ~~~
 
 ### services stop (service_name)
@@ -32,6 +36,14 @@ Write-Output "Starting service $env:service_name"
 
 ~~~bash
 echo "Stopping service $service_name"
+~~~
+
+~~~powershell
+param(
+    $service_name = $service_name
+)
+
+Write-Output "Stopping service $service_name"
 ~~~
 "#,
     );

--- a/tests/supported_runtimes_test.rs
+++ b/tests/supported_runtimes_test.rs
@@ -27,6 +27,27 @@ echo "this won't do anything..."
         .failure();
 }
 
+#[cfg(windows)]
+#[test]
+fn powershell() {
+    let (_temp, maskfile_path) = common::maskfile(
+        r#"
+## powershell
+~~~powershell
+Write-Output "Hello, $env:name!"
+~~~
+"#,
+    );
+
+    common::run_mask(&maskfile_path)
+        .command("powershell")
+        .env("name", "World")
+        .assert()
+        .stdout(contains("Hello, World!"))
+        .success();
+}
+
+#[cfg(not(windows))]
 #[test]
 fn sh() {
     let (_temp, maskfile_path) = common::maskfile(
@@ -46,6 +67,7 @@ echo Hello, $name!
         .success();
 }
 
+#[cfg(not(windows))]
 #[test]
 fn bash() {
     let (_temp, maskfile_path) = common::maskfile(

--- a/tests/supported_runtimes_test.rs
+++ b/tests/supported_runtimes_test.rs
@@ -34,13 +34,57 @@ fn powershell() {
         r#"
 ## powershell
 ~~~powershell
-Write-Output "Hello, $env:name!"
+param (
+    $name = $env:name
+)
+
+Write-Output "Hello, $name!"
 ~~~
 "#,
     );
 
     common::run_mask(&maskfile_path)
         .command("powershell")
+        .env("name", "World")
+        .assert()
+        .stdout(contains("Hello, World!"))
+        .success();
+}
+
+#[cfg(windows)]
+#[test]
+fn batch() {
+    let (_temp, maskfile_path) = common::maskfile(
+        r#"
+## batch
+~~~batch
+echo "Hello, %name%!"
+~~~
+"#,
+    );
+
+    common::run_mask(&maskfile_path)
+        .command("batch")
+        .env("name", "World")
+        .assert()
+        .stdout(contains("Hello, World!"))
+        .success();
+}
+
+#[cfg(windows)]
+#[test]
+fn cmd() {
+    let (_temp, maskfile_path) = common::maskfile(
+        r#"
+## cmd
+~~~cmd
+echo "Hello, %name%!"
+~~~
+"#,
+    );
+
+    common::run_mask(&maskfile_path)
+        .command("cmd")
         .env("name", "World")
         .assert()
         .stdout(contains("Hello, World!"))


### PR DESCRIPTION
<!--
Please review our Contribution Guidelines (CONTRIBUTING.md) before creating an issue or submitting a PR 🙌
-->

### Which issue does this fix?
<!-- Replace 10 with the issue number you've fixed -->

Closes #10


### Describe the solution
Added batch and powershell scripting for windows.  

Powershell worked out of the box with some minor idiosyncrasies (more on that in a moment) and batch just required a new match statement for the runtime.   CFG was used for batch and for a few of the tests.  Each instance of shell/bash in the tests and maskfile.md was given a complimentary powershell script as well.  On the Linux/WSL side, had to make some changes to the parser because it didn't ignore the powershell and batch blocks.  Used CFG to change the way the parser matches on codeblock tags.  

Regarding Powershell: normally when using powershell you are not allowed to pass double hyphen flags `--` to a script.  This somewhat dubious choice doesn't seem to affect mask since the arguments are passed into the environment.   If you pass a flag x as such `--x` you are able to gain access to the value of the flag via `$env:x`.  This works out nicely because there doesn't need to be two separate CLI interfaces for windows and Linux.   

The Paths in windows are proceeded by `\\?\`, for instance: `\\?\C:\\path\\to\\maskfile.md`.  If this prefix is removed from the path, it will work without issue in Mask/Rust.  Only had to do this one time and it was done via Powershell.   

Edit: one more thing worth mentioning is that I am not the most experienced powershell dev.  I tried to make all of the blocks consistent but there are a few items that might not be completely idiomatic. 
