### PR TITLE
Optional, hidden, and alias support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,159 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug unit tests in library 'mask'",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--lib",
+          "--package=mask"
+        ],
+        "filter": {
+          "name": "mask",
+          "kind": "lib"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug executable 'mask'",
+      "cargo": {
+        "args": [
+          "build",
+          "--bin=mask",
+          "--package=mask"
+        ],
+        "filter": {
+          "name": "mask",
+          "kind": "bin"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug unit tests in executable 'mask'",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--bin=mask",
+          "--package=mask"
+        ],
+        "filter": {
+          "name": "mask",
+          "kind": "bin"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug integration test 'subcommands_test'",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--test=subcommands_test",
+          "--package=mask"
+        ],
+        "filter": {
+          "name": "subcommands_test",
+          "kind": "test"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug integration test 'supported_runtimes_test'",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--test=supported_runtimes_test",
+          "--package=mask"
+        ],
+        "filter": {
+          "name": "supported_runtimes_test",
+          "kind": "test"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug integration test 'integration_test'",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--test=integration_test",
+          "--package=mask"
+        ],
+        "filter": {
+          "name": "integration_test",
+          "kind": "test"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug integration test 'env_vars_test'",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--test=env_vars_test",
+          "--package=mask"
+        ],
+        "filter": {
+          "name": "env_vars_test",
+          "kind": "test"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug integration test 'arguments_and_flags_test'",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--test=arguments_and_flags_test",
+          "--package=mask"
+        ],
+        "filter": {
+          "name": "arguments_and_flags_test",
+          "kind": "test"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "lldb.dereferencePointers": true,
+  "lldb.displayFormat": "auto"
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -2,10 +2,11 @@
 pub struct Command {
     pub cmd_level: u8,
     pub name: String,
+    pub alias: String,
     pub desc: String,
     pub script: Script,
     pub subcommands: Vec<Command>,
-    pub required_args: Vec<RequiredArg>,
+    pub args: Vec<Arg>,
     pub option_flags: Vec<OptionFlag>,
 }
 
@@ -14,10 +15,11 @@ impl Command {
         Self {
             cmd_level,
             name: "".to_string(),
+            alias: "".to_string(),
             desc: "".to_string(),
             script: Script::new(),
             subcommands: vec![],
-            required_args: vec![],
+            args: vec![],
             option_flags: vec![],
         }
     }
@@ -62,16 +64,18 @@ impl Script {
 }
 
 #[derive(Debug, Clone)]
-pub struct RequiredArg {
+pub struct Arg {
     pub name: String,
     pub val: String,
+    pub required: bool,
 }
 
-impl RequiredArg {
-    pub fn new(name: String) -> Self {
-        Self {
+impl Arg {
+    pub fn new(name: String, required: bool) -> Self {
+        Arg {
             name,
             val: "".to_string(),
+            required,
         }
     }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -94,7 +94,7 @@ fn add_utility_variables(mut child: process::Command, maskfile_path: String) -> 
 
 fn add_flag_variables(mut child: process::Command, cmd: &Command) -> process::Command {
     // Add all required args as environment variables
-    for arg in &cmd.required_args {
+    for arg in &cmd.args {
         child.env(arg.name.clone(), arg.val.clone());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,10 +101,10 @@ fn build_subcommands<'a, 'b>(
             }
         }
 
-        // Add all required arguments
-        for a in &c.required_args {
-            let arg = Arg::with_name(&a.name).required(true);
-            subcmd = subcmd.arg(arg);
+        // Add all required and optional arguments
+        for a in &c.args {
+            let arg = Arg::with_name(&a.name);
+            subcmd = subcmd.arg(arg.required(a.required));
         }
 
         // Add all optional flags
@@ -116,6 +116,12 @@ fn build_subcommands<'a, 'b>(
                 .takes_value(f.takes_value)
                 .multiple(f.multiple);
             subcmd = subcmd.arg(arg);
+        }
+        if c.name.starts_with('_') {
+            subcmd = subcmd.setting(AppSettings::Hidden);
+        }
+        if c.alias != "" {
+            subcmd = subcmd.visible_alias(c.alias.as_str());
         }
         cli_app = cli_app.subcommand(subcmd);
     }
@@ -144,7 +150,7 @@ fn find_command<'a>(matches: &ArgMatches, subcommands: &Vec<Command>) -> Option<
 
 fn get_command_options(mut cmd: Command, matches: &ArgMatches) -> Command {
     // Check all required args
-    for arg in &mut cmd.required_args {
+    for arg in &mut cmd.args {
         arg.val = matches.value_of(arg.name.clone()).unwrap().to_string();
     }
 


### PR DESCRIPTION
<!--
Please review our Contribution Guidelines (CONTRIBUTING.md) before creating an issue or submitting a PR 🙌
-->

### Which issue does this fix?
<!-- Replace {ISSUE} with the issue number you've fixed -->

Closes #5



### Describe the solution
<!-- Add some details about what you did to fix the issue -->

This change adds support for subcommand alias, hidden subcommands, and optional arguments.

Subcommand aliases can be specified by separating the command name with "//".
So `# command (arg)` becomes `# command//c (arg)`.

Commands can be hidden from the help screen by simply prefixing the command name with "_".

To make an argument optional, simply add a question mark. `(optional?)`