### PR TITLE
Fix issue where command before level 1 heading was ignored

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -21,9 +21,12 @@ pub fn build_command_structure(maskfile_contents: String) -> Command {
                 match tag {
                     Tag::Header(heading_level) => {
                         // Add the last command before starting a new one.
-                        // Don't add the first command during the first iteration.
+                        // Don't add commands for level 1 heading blocks (the title).
                         if heading_level > 1 {
                             commands.push(current_command.build());
+                        } else if heading_level == 1 && commands.len() > 0 {
+                            // Found another level 1 heading block, so quit parsing.
+                            break;
                         }
                         current_command = Command::new(heading_level as u8);
                     }

--- a/tests/subcommands_test.rs
+++ b/tests/subcommands_test.rs
@@ -131,3 +131,52 @@ echo "Start all services"
             .success();
     }
 }
+
+mod when_another_level_1_heading_is_found {
+    use super::*;
+
+    #[test]
+    fn subcommands_above_level_1_work() {
+        let (_temp, maskfile_path) = common::maskfile(
+            r#"
+## start
+~~~bash
+echo "start"
+~~~
+
+# invalid level 1 heading
+"#,
+        );
+
+        common::run_mask(&maskfile_path)
+            .cli("start")
+            .assert()
+            .stdout(contains("start"))
+            .success();
+    }
+
+    #[test]
+    fn subcommands_below_level_1_are_ignored() {
+        let (_temp, maskfile_path) = common::maskfile(
+            r#"
+## start
+~~~bash
+echo "start"
+~~~
+
+# invalid level 1 heading
+
+## ignored
+~~~bash
+echo "ignored"
+~~~
+"#,
+        );
+
+        common::run_mask(&maskfile_path)
+            .cli("ignored")
+            .assert()
+            .stderr(contains("error: Found argument 'ignored' which wasn't expected, or isn't valid in this context"))
+            .failure();
+    }
+}


### PR DESCRIPTION
The command before a level 1 heading wasn't being pushed into the array of commands (line 26 in the parser).

However, after the parser is done, the last command was correctly being added to the list of commands. The problem was that when a level 1 heading is found, that last command is overwritten and lost.

<!--
Please review our Contribution Guidelines (CONTRIBUTING.md) before creating an issue or submitting a PR 🙌
-->

### Which issue does this fix?
<!-- Replace {ISSUE} with the issue number you've fixed -->

Closes #75



### Describe the solution

I decided that if we see another level 1 heading within the document, the parser should stop (break) there. Anything below that level 1 heading will be ignored... so that might be a good place to put documentation or other content.
