### PR TITLE
Rename option_flags to named_flags

### DIFF
--- a/mask-parser/src/maskfile.rs
+++ b/mask-parser/src/maskfile.rs
@@ -22,7 +22,7 @@ pub struct Command {
     pub script: Option<Script>,
     pub subcommands: Vec<Command>,
     pub required_args: Vec<RequiredArg>,
-    pub option_flags: Vec<OptionFlag>,
+    pub named_flags: Vec<NamedFlag>,
 }
 
 impl Command {
@@ -34,7 +34,7 @@ impl Command {
             script: Some(Script::new()),
             subcommands: vec![],
             required_args: vec![],
-            option_flags: vec![],
+            named_flags: vec![],
         }
     }
 
@@ -48,7 +48,7 @@ impl Command {
 
         // Auto add common flags like verbose for commands that have a script source
         if self.script.is_some() {
-            self.option_flags.push(OptionFlag {
+            self.named_flags.push(NamedFlag {
                 name: "verbose".to_string(),
                 description: "Sets the level of verbosity".to_string(),
                 short: "v".to_string(),
@@ -99,7 +99,7 @@ impl RequiredArg {
 }
 
 #[derive(Debug, Serialize, Clone)]
-pub struct OptionFlag {
+pub struct NamedFlag {
     pub name: String,
     pub description: String,
     pub short: String,            // v        (used as -v)
@@ -113,7 +113,7 @@ pub struct OptionFlag {
     pub val: String,
 }
 
-impl OptionFlag {
+impl NamedFlag {
     pub fn new() -> Self {
         Self {
             name: "".to_string(),

--- a/mask-parser/src/parser.rs
+++ b/mask-parser/src/parser.rs
@@ -6,7 +6,7 @@ pub fn parse(maskfile_contents: String) -> Maskfile {
     let parser = create_markdown_parser(&maskfile_contents);
     let mut commands = vec![];
     let mut current_command = Command::new(1);
-    let mut current_option_flag = OptionFlag::new();
+    let mut current_option_flag = NamedFlag::new();
     let mut text = "".to_string();
     let mut list_level = 0;
 
@@ -88,9 +88,9 @@ pub fn parse(maskfile_contents: String) -> Maskfile {
                     if list_level == 1 {
                         // Add the current one to the list and start a new one
                         current_command
-                            .option_flags
+                            .named_flags
                             .push(current_option_flag.clone());
-                        current_option_flag = OptionFlag::new();
+                        current_option_flag = NamedFlag::new();
                     }
                 }
                 _ => (),
@@ -320,7 +320,7 @@ mod parse {
                                 "name": "port"
                             }
                         ],
-                        "option_flags": [verbose_flag],
+                        "named_flags": [verbose_flag],
                     },
                     {
                         "level": 2,
@@ -336,7 +336,7 @@ mod parse {
                                 "name": "name"
                             }
                         ],
-                        "option_flags": [verbose_flag],
+                        "named_flags": [verbose_flag],
                     },
                     {
                         "level": 2,
@@ -354,11 +354,11 @@ mod parse {
                                 },
                                 "subcommands": [],
                                 "required_args": [],
-                                "option_flags": [verbose_flag],
+                                "named_flags": [verbose_flag],
                             }
                         ],
                         "required_args": [],
-                        "option_flags": [],
+                        "named_flags": [],
                     }
                 ]
             }),

--- a/mask/src/executor.rs
+++ b/mask/src/executor.rs
@@ -105,8 +105,8 @@ fn add_flag_variables(mut child: process::Command, cmd: &Command) -> process::Co
         child.env(arg.name.clone(), arg.val.clone());
     }
 
-    // Add all optional flags as environment variables if they have a value
-    for flag in &cmd.option_flags {
+    // Add all named flags as environment variables if they have a value
+    for flag in &cmd.named_flags {
         if flag.val != "" {
             child.env(flag.name.clone(), flag.val.clone());
         }

--- a/mask/src/main.rs
+++ b/mask/src/main.rs
@@ -108,7 +108,7 @@ fn build_subcommands<'a, 'b>(
         }
 
         // Add all named flags
-        for f in &c.option_flags {
+        for f in &c.named_flags {
             let arg = Arg::with_name(&f.name)
                 .help(&f.description)
                 .short(&f.short)
@@ -149,8 +149,8 @@ fn get_command_options(mut cmd: Command, matches: &ArgMatches) -> Command {
         arg.val = matches.value_of(arg.name.clone()).unwrap().to_string();
     }
 
-    // Check all optional flags
-    for flag in &mut cmd.option_flags {
+    // Check all named flags
+    for flag in &mut cmd.named_flags {
         flag.val = if flag.takes_value {
             // Extract the value
             let raw_value = matches

--- a/mask/tests/arguments_and_flags_test.rs
+++ b/mask/tests/arguments_and_flags_test.rs
@@ -48,7 +48,7 @@ Write-Output "Testing $test_case in $file"
 }
 
 #[test]
-fn optional_flags() {
+fn named_flags() {
     let (_temp, maskfile_path) = common::maskfile(
         r#"
 ## serve


### PR DESCRIPTION
Optional flags recently got the ability to be marked as required... so "optional flags" doesn't really make sense anymore. 

"Named flags" is what we went with.