### PR TITLE
Add --maskfile-introspect flag to print out the maskfile command structure as json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,7 @@ dependencies = [
  "colored",
  "mask-parser",
  "predicates",
+ "serde_json",
 ]
 
 [[package]]

--- a/mask/Cargo.toml
+++ b/mask/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 
 [dependencies]
 colored = "2"                                                           # https://github.com/mackwic/colored
+serde_json = "1.0"                                                      # https://github.com/serde-rs/json
 mask-parser = { path = "../mask-parser" }
 
 [dependencies.clap]                                                     # https://github.com/clap-rs/clap

--- a/mask/tests/introspect_test.rs
+++ b/mask/tests/introspect_test.rs
@@ -1,0 +1,59 @@
+mod common;
+use assert_cmd::prelude::*;
+use predicates::str::contains;
+use serde_json::json;
+
+#[test]
+fn outputs_the_maskfile_structure_as_json() {
+    let (_temp, maskfile_path) = common::maskfile(
+        r#"
+# Document Title
+
+## somecommand
+> The command description
+
+~~~bash
+echo something
+~~~
+"#,
+    );
+
+    let verbose_flag = json!({
+        "name": "verbose",
+        "description": "Sets the level of verbosity",
+        "short": "v",
+        "long": "verbose",
+        "multiple": false,
+        "takes_value": false,
+        "required": false,
+        "validate_as_number": false,
+    });
+
+    let expected_json = json!({
+        "title": "Document Title",
+        "description": "",
+        "commands": [
+            {
+                "level": 2,
+                "name": "somecommand",
+                "description": "The command description",
+                "script": {
+                    "executor": "bash",
+                    "source": "echo something\n",
+                },
+                "subcommands": [],
+                "required_args": [],
+                "named_flags": [verbose_flag],
+            }
+        ]
+    });
+
+    common::run_mask(&maskfile_path)
+        .arg("--maskfile-introspect")
+        .assert()
+        .code(0)
+        .stdout(contains(
+            serde_json::to_string_pretty(&expected_json).unwrap(),
+        ))
+        .success();
+}


### PR DESCRIPTION
I've heard from a few different users that they want the ability to generate autocomplete commands for mask. Up until now, I've been suggesting that parsing the maskfile for command headings was a good enough solution. However, parsing out named flags and arguments becomes much more difficult.

Today I published mask-parser which contains all of the parsing logic mask uses for the `maskfile.md` format. 

This PR adds a flag to mask `--maskfile-introspect` which prints out the entire maskfile command structure as json which can be consumed by other programs/libs at runtime. This should be helpful for tools that need to generate autocomplete commands.
