### PR TITLE
Rename --maskfile-introspect flag to --introspect

### DIFF
--- a/mask/src/main.rs
+++ b/mask/src/main.rs
@@ -82,7 +82,7 @@ fn find_maskfile() -> (Result<String, String>, String) {
 fn is_introspecting() -> bool {
     let args: Vec<String> = env::args().collect();
     for a in args {
-        if a == "--maskfile-introspect" {
+        if a == "--introspect" {
             return true;
         }
     }
@@ -103,9 +103,9 @@ fn custom_maskfile_path_arg<'a, 'b>() -> Arg<'a, 'b> {
 
 /// Print out the maskfile structure in json
 fn introspect_arg<'a, 'b>() -> Arg<'a, 'b> {
-    Arg::with_name("maskfile-introspect")
+    Arg::with_name("introspect")
         .help("Print out the maskfile command structure in json")
-        .long("maskfile-introspect")
+        .long("introspect")
         .multiple(false)
 }
 

--- a/mask/tests/introspect_test.rs
+++ b/mask/tests/introspect_test.rs
@@ -49,7 +49,7 @@ echo something
     });
 
     common::run_mask(&maskfile_path)
-        .arg("--maskfile-introspect")
+        .arg("--introspect")
         .assert()
         .code(0)
         .stdout(contains(


### PR DESCRIPTION
Just realized that `--maskfile-introspect` is overly specific. I originally went with that because I don't want mask-specific flags to conflict with user-specified command flags. 

However, I forgot that mask flags are only defined at the top level and therefore user flags will not conflict with them. So going with a shorter `--introspect` flag actually is fine.
